### PR TITLE
Update portable to 11.8.1

### DIFF
--- a/browser-portable/latest.json
+++ b/browser-portable/latest.json
@@ -1,6 +1,6 @@
 {
     "win-x86-64": {
-        "version": "11.7.1",
-        "url": "https://github.com/Floorp-Projects/Floorp-Portable/releases/download/11.7.1-portable/floorp-11.7.1-portable-windows-x86_64.zip"
+        "version": "11.8.1",
+        "url": "https://github.com/Floorp-Projects/Floorp-Portable/releases/download/11.8.1-portable/floorp-11.8.1-portable-windows-x86_64.zip"
     }
 }


### PR DESCRIPTION
[latest.json](https://github.com/Floorp-Projects/Floorp-Updates/blob/main/browser-portable/latest.json)の更新