### PR TITLE
fix(updates): add fail-closed stable delivery v2

### DIFF
--- a/.github/workflows/deliver-updates-to-floorp-browser.yml
+++ b/.github/workflows/deliver-updates-to-floorp-browser.yml
@@ -41,6 +41,10 @@ on:
 
 name: Deliver updates to Floorp Browser
 
+concurrency:
+  group: floorp-updates-writer
+  cancel-in-progress: false
+
 jobs:
   deliver-updates:
     runs-on: ubuntu-22.04
@@ -54,9 +58,22 @@ jobs:
           echo "TARGET_OS=${{ inputs.os }}" >> $GITHUB_ENV
 
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
+          fetch-depth: 0
+          ref: main
           token: ${{ secrets.PAT }}
+
+      - name: Capture and verify base SHA
+        run: |
+          set -euo pipefail
+          BASE_SHA=$(git rev-parse HEAD)
+          REMOTE_SHA=$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')
+          if [[ "$REMOTE_SHA" != "$BASE_SHA" ]]; then
+            echo "Checked-out main $BASE_SHA does not match remote main $REMOTE_SHA" >&2
+            exit 1
+          fi
+          echo "BASE_SHA=$BASE_SHA" >> "$GITHUB_ENV"
 
       - name: Calculate mar file size
         run: |
@@ -133,31 +150,60 @@ jobs:
 
       - name: Copy files
         run: |
+          set -euo pipefail
+          if [[ ! "$DISPLAY_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "DISPLAY_VERSION must be a numeric three-part legacy version" >&2
+            exit 1
+          fi
+          LEGACY_PATHS_FILE="$RUNNER_TEMP/legacy-update-paths.txt"
+          : > "$LEGACY_PATHS_FILE"
+          echo "LEGACY_PATHS_FILE=$LEGACY_PATHS_FILE" >> "$GITHUB_ENV"
+
           mkdir -p browser/${{ env.DISPLAY_VERSION }}/${{ inputs.os }}/${{ inputs.arch }}
-          for dir in $(ls -l browser | grep ^d | awk '{print $9}'); do
-            echo $dir
-            mkdir -p browser/${dir}/${{ inputs.os }}/${{ inputs.arch }}
-            if [[ "$dir" != "beta" ]]; then
-              if [[ "$dir" == "${{ env.DISPLAY_VERSION }}" ]]; then
-                cp ~/update_tmpfiles/update_notfound.xml browser/${dir}/${{ inputs.os }}/${{ inputs.arch }}/update.xml
-              else
-                cp ~/update_tmpfiles/update_found.xml browser/${dir}/${{ inputs.os }}/${{ inputs.arch }}/update.xml
-              fi
+          while IFS= read -r dir; do
+            if [[ ! "$dir" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Skipping reserved or non-version browser directory: $dir"
+              continue
             fi
-          done
+            echo "$dir"
+            mkdir -p browser/${dir}/${{ inputs.os }}/${{ inputs.arch }}
+            TARGET_PATH="browser/${dir}/${{ inputs.os }}/${{ inputs.arch }}/update.xml"
+            if [[ "$dir" == "${{ env.DISPLAY_VERSION }}" ]]; then
+              cp ~/update_tmpfiles/update_notfound.xml "$TARGET_PATH"
+            else
+              cp ~/update_tmpfiles/update_found.xml "$TARGET_PATH"
+            fi
+            printf '%s\n' "$TARGET_PATH" >> "$LEGACY_PATHS_FILE"
+          done < <(find browser -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
 
           mkdir -p systemAddon/xml/${{ env.DISPLAY_VERSION }}/${{ inputs.os }}
-          cp ~/update_tmpfiles/update_addon.xml systemAddon/xml/${{ env.DISPLAY_VERSION }}/${{ inputs.os }}/update.xml
+          ADDON_PATH="systemAddon/xml/${{ env.DISPLAY_VERSION }}/${{ inputs.os }}/update.xml"
+          cp ~/update_tmpfiles/update_addon.xml "$ADDON_PATH"
+          printf '%s\n' "$ADDON_PATH" >> "$LEGACY_PATHS_FILE"
 
       - name: Commit
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          while IFS= read -r path; do
+            if [[ "$path" =~ ^browser/[0-9]+\.[0-9]+\.[0-9]+/(WINNT|Linux|Darwin)/(x86_64|x86|aarch64)/update\.xml$ ]] || \
+               [[ "$path" =~ ^systemAddon/xml/[0-9]+\.[0-9]+\.[0-9]+/(WINNT|Linux|Darwin)/update\.xml$ ]]; then
+              git add -- "$path"
+            else
+              echo "Refusing to stage unexpected legacy path: $path" >&2
+              exit 1
+            fi
+          done < "$LEGACY_PATHS_FILE"
           if git diff --cached --quiet; then
             echo "🛈 変更がないためコミットをスキップします。"
             exit 0
           fi
+          git fetch --no-tags origin main
+          REMOTE_SHA=$(git rev-parse origin/main)
+          if [[ "$REMOTE_SHA" != "$BASE_SHA" ]]; then
+            echo "Remote main drifted from $BASE_SHA to $REMOTE_SHA; refusing stale legacy update" >&2
+            exit 1
+          fi
           git commit -m "A new version of Floorp Browser has been released! (${{ env.DISPLAY_VERSION }} - ${{ inputs.os }} ${{ inputs.arch }})"
-          git pull -r
-          git push origin
+          git push origin HEAD:main

--- a/.github/workflows/update-stable-updatexml-files-v2.yml
+++ b/.github/workflows/update-stable-updatexml-files-v2.yml
@@ -1,0 +1,350 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+name: Deliver Floorp Stable updates v2
+run-name: Stable v2 ${{ inputs['app-version2'] }} (${{ inputs['request-id'] }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      win-mar-url:
+        type: string
+        required: true
+        description: Windows x86_64 complete MAR file URL
+      linux-mar-url:
+        type: string
+        required: true
+        description: Linux x86_64 complete MAR file URL
+      linux-aarch64-mar-url:
+        type: string
+        required: true
+        description: Linux aarch64 complete MAR file URL
+      mac-mar-url:
+        type: string
+        required: true
+        description: macOS Universal complete MAR file URL
+      win-meta-url:
+        type: string
+        required: true
+        description: Windows schema-v2 metadata URL
+      linux-meta-url:
+        type: string
+        required: true
+        description: Linux x86_64 schema-v2 metadata URL
+      linux-aarch64-meta-url:
+        type: string
+        required: true
+        description: Linux aarch64 schema-v2 metadata URL
+      mac-meta-url:
+        type: string
+        required: true
+        description: macOS schema-v2 metadata URL
+      firefox-version:
+        type: string
+        required: true
+        description: Firefox version (for example, 153.0)
+      app-version2:
+        type: string
+        required: true
+        description: Floorp version (for example, 12.16.4)
+      request-id:
+        type: string
+        required: true
+        description: Unique caller correlation ID
+      dry-run:
+        type: boolean
+        required: false
+        default: false
+        description: Validate and generate artifacts without committing or deploying
+
+permissions:
+  contents: write
+
+concurrency:
+  group: floorp-updates-writer
+  cancel-in-progress: false
+
+jobs:
+  deliver-stable-updates-v2:
+    runs-on: ubuntu-22.04
+    env:
+      APP_VERSION2: ${{ inputs['app-version2'] }}
+      DRY_RUN: ${{ inputs['dry-run'] }}
+      FIREFOX_VERSION: ${{ inputs['firefox-version'] }}
+      LINUX_AARCH64_MAR_URL: ${{ inputs['linux-aarch64-mar-url'] }}
+      LINUX_AARCH64_META_URL: ${{ inputs['linux-aarch64-meta-url'] }}
+      LINUX_MAR_URL: ${{ inputs['linux-mar-url'] }}
+      LINUX_META_URL: ${{ inputs['linux-meta-url'] }}
+      MAC_MAR_URL: ${{ inputs['mac-mar-url'] }}
+      MAC_META_URL: ${{ inputs['mac-meta-url'] }}
+      REQUEST_ID: ${{ inputs['request-id'] }}
+      WIN_MAR_URL: ${{ inputs['win-mar-url'] }}
+      WIN_META_URL: ${{ inputs['win-meta-url'] }}
+    steps:
+      - name: Checkout exact main base
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ secrets.PAT }}
+
+      - name: Capture and verify base SHA
+        id: base
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$REQUEST_ID" =~ ^[A-Za-z0-9._-]{1,80}$ ]]; then
+            echo "request-id must match ^[A-Za-z0-9._-]{1,80}$" >&2
+            exit 1
+          fi
+          BASE_SHA=$(git rev-parse HEAD)
+          REMOTE_SHA=$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')
+          if [[ "$REMOTE_SHA" != "$BASE_SHA" ]]; then
+            echo "Checked-out main $BASE_SHA does not match remote main $REMOTE_SHA" >&2
+            exit 1
+          fi
+          echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Validate canonical release URLs
+        shell: bash
+        run: |
+          set -euo pipefail
+          RELEASE_BASE="https://github.com/Floorp-Projects/Floorp/releases/download/v${APP_VERSION2}"
+          expect_url() {
+            local actual=$1
+            local expected=$2
+            local label=$3
+            if [[ "$actual" != "$expected" ]]; then
+              echo "$label must be exactly $expected" >&2
+              exit 1
+            fi
+          }
+          expect_url "$WIN_MAR_URL" "$RELEASE_BASE/floorp-windows-x86_64-full.mar" "win-mar-url"
+          expect_url "$LINUX_MAR_URL" "$RELEASE_BASE/floorp-linux-x86_64-full.mar" "linux-mar-url"
+          expect_url "$LINUX_AARCH64_MAR_URL" "$RELEASE_BASE/floorp-linux-aarch64-full.mar" "linux-aarch64-mar-url"
+          expect_url "$MAC_MAR_URL" "$RELEASE_BASE/floorp-mac-universal-full.mar" "mac-mar-url"
+          expect_url "$WIN_META_URL" "$RELEASE_BASE/win-meta.json" "win-meta-url"
+          expect_url "$LINUX_META_URL" "$RELEASE_BASE/linux-meta.json" "linux-meta-url"
+          expect_url "$LINUX_AARCH64_META_URL" "$RELEASE_BASE/linux-aarch64-meta.json" "linux-aarch64-meta-url"
+          expect_url "$MAC_META_URL" "$RELEASE_BASE/mac-meta.json" "mac-meta-url"
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2.0.5
+        with:
+          deno-version: v2.x
+
+      - name: Run validator regression tests
+        run: deno test --allow-read --allow-write scripts/stable-update-v2_test.ts
+
+      - name: Download metadata and MAR files
+        id: downloads
+        shell: bash
+        run: |
+          set -euo pipefail
+          WORK_DIR="$RUNNER_TEMP/stable-update-v2-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          mkdir -p "$WORK_DIR"
+          download() {
+            local url=$1
+            local output=$2
+            curl --fail --show-error --silent --location \
+              --proto '=https' --tlsv1.2 --retry 3 \
+              --output "$output" "$url"
+          }
+          download "$WIN_META_URL" "$WORK_DIR/win-meta.json"
+          download "$LINUX_META_URL" "$WORK_DIR/linux-meta.json"
+          download "$LINUX_AARCH64_META_URL" "$WORK_DIR/linux-aarch64-meta.json"
+          download "$MAC_META_URL" "$WORK_DIR/mac-meta.json"
+          download "$WIN_MAR_URL" "$WORK_DIR/windows.mar"
+          download "$LINUX_MAR_URL" "$WORK_DIR/linux.mar"
+          download "$LINUX_AARCH64_MAR_URL" "$WORK_DIR/linux-aarch64.mar"
+          download "$MAC_MAR_URL" "$WORK_DIR/mac.mar"
+          echo "work_dir=$WORK_DIR" >> "$GITHUB_OUTPUT"
+
+      - name: Validate manifest set and generate five endpoints
+        id: apply
+        env:
+          WORK_DIR: ${{ steps.downloads.outputs.work_dir }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          APPLY_JSON=$(deno run --allow-read --allow-write scripts/stable-update-v2.ts \
+            --firefox-version "$FIREFOX_VERSION" \
+            --app-version2 "$APP_VERSION2" \
+            --state-file browser/stable/stable-state.json \
+            --output-root browser/stable \
+            --windows-meta "$WORK_DIR/win-meta.json" \
+            --windows-mar "$WORK_DIR/windows.mar" \
+            --windows-mar-url "$WIN_MAR_URL" \
+            --linux-meta "$WORK_DIR/linux-meta.json" \
+            --linux-mar "$WORK_DIR/linux.mar" \
+            --linux-mar-url "$LINUX_MAR_URL" \
+            --linuxAarch64-meta "$WORK_DIR/linux-aarch64-meta.json" \
+            --linuxAarch64-mar "$WORK_DIR/linux-aarch64.mar" \
+            --linuxAarch64-mar-url "$LINUX_AARCH64_MAR_URL" \
+            --mac-meta "$WORK_DIR/mac-meta.json" \
+            --mac-mar "$WORK_DIR/mac.mar" \
+            --mac-mar-url "$MAC_MAR_URL")
+          TRANSITION=$(jq -er '.result | select(. == "updated" or . == "noop")' <<< "$APPLY_JSON")
+          MANIFEST_SET_ID=$(jq -er '.manifest_set_id' browser/stable/stable-state.json)
+          echo "transition=$TRANSITION" >> "$GITHUB_OUTPUT"
+          echo "manifest_set_id=$MANIFEST_SET_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Build dry-run diff
+        if: ${{ inputs['dry-run'] }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git diff --binary -- \
+            browser/stable/WINNT/x86_64/update.xml \
+            browser/stable/Linux/x86_64/update.xml \
+            browser/stable/Linux/aarch64/update.xml \
+            browser/stable/Darwin/x86_64/update.xml \
+            browser/stable/Darwin/aarch64/update.xml \
+            browser/stable/stable-state.json \
+            > "$RUNNER_TEMP/stable-update.diff"
+
+      - name: Commit and push exact stable paths
+        id: commit
+        if: ${{ !inputs['dry-run'] && steps.apply.outputs.transition == 'updated' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE_SHA=${{ steps.base.outputs.base_sha }}
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- \
+            browser/stable/WINNT/x86_64/update.xml \
+            browser/stable/Linux/x86_64/update.xml \
+            browser/stable/Linux/aarch64/update.xml \
+            browser/stable/Darwin/x86_64/update.xml \
+            browser/stable/Darwin/aarch64/update.xml \
+            browser/stable/stable-state.json
+          if git diff --cached --quiet; then
+            echo "Validator reported an update but no exact stable path changed" >&2
+            exit 1
+          fi
+          git fetch --no-tags origin main
+          REMOTE_SHA=$(git rev-parse origin/main)
+          if [[ "$REMOTE_SHA" != "$BASE_SHA" ]]; then
+            echo "Remote main drifted from $BASE_SHA to $REMOTE_SHA; refusing stale update" >&2
+            exit 1
+          fi
+          git commit -m "Update Floorp Stable v2 (${APP_VERSION2}; ${REQUEST_ID})"
+          UPDATES_COMMIT_SHA=$(git rev-parse HEAD)
+          git push origin HEAD:main
+          echo "updates_commit_sha=$UPDATES_COMMIT_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Confirm no-op did not modify endpoints
+        if: ${{ !inputs['dry-run'] && steps.apply.outputs.transition == 'noop' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git diff --quiet -- \
+            browser/stable/WINNT/x86_64/update.xml \
+            browser/stable/Linux/x86_64/update.xml \
+            browser/stable/Linux/aarch64/update.xml \
+            browser/stable/Darwin/x86_64/update.xml \
+            browser/stable/Darwin/aarch64/update.xml \
+            browser/stable/stable-state.json
+
+      - name: Create correlated result
+        id: result
+        env:
+          BASE_SHA: ${{ steps.base.outputs.base_sha }}
+          MANIFEST_SET_ID: ${{ steps.apply.outputs.manifest_set_id }}
+          PUSHED_SHA: ${{ steps.commit.outputs.updates_commit_sha }}
+          TRANSITION: ${{ steps.apply.outputs.transition }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          endpoint_hash() {
+            printf 'sha256:%s' "$(sha256sum "$1" | cut -d' ' -f1)"
+          }
+          WIN_HASH=$(endpoint_hash browser/stable/WINNT/x86_64/update.xml)
+          LINUX_HASH=$(endpoint_hash browser/stable/Linux/x86_64/update.xml)
+          LINUX_AARCH64_HASH=$(endpoint_hash browser/stable/Linux/aarch64/update.xml)
+          MAC_X64_HASH=$(endpoint_hash browser/stable/Darwin/x86_64/update.xml)
+          MAC_AARCH64_HASH=$(endpoint_hash browser/stable/Darwin/aarch64/update.xml)
+
+          if [[ "$DRY_RUN" == "true" ]]; then
+            STATUS=dry-run
+            UPDATES_COMMIT_SHA=""
+            DEPLOY_REQUIRED=false
+          elif [[ "$TRANSITION" == "updated" ]]; then
+            STATUS=updated
+            UPDATES_COMMIT_SHA=$PUSHED_SHA
+            DEPLOY_REQUIRED=true
+          else
+            STATUS=noop
+            UPDATES_COMMIT_SHA=$BASE_SHA
+            DEPLOY_REQUIRED=false
+          fi
+
+          RESULT_FILE="$RUNNER_TEMP/stable-update-result.json"
+          jq -n \
+            --arg request_id "$REQUEST_ID" \
+            --arg status "$STATUS" \
+            --arg transition "$TRANSITION" \
+            --arg manifest_set_id "$MANIFEST_SET_ID" \
+            --arg base_sha "$BASE_SHA" \
+            --arg updates_commit_sha "$UPDATES_COMMIT_SHA" \
+            --argjson deploy_required "$DEPLOY_REQUIRED" \
+            --arg win_hash "$WIN_HASH" \
+            --arg linux_hash "$LINUX_HASH" \
+            --arg linux_aarch64_hash "$LINUX_AARCH64_HASH" \
+            --arg mac_x64_hash "$MAC_X64_HASH" \
+            --arg mac_aarch64_hash "$MAC_AARCH64_HASH" \
+            '{
+              schema_version: 1,
+              request_id: $request_id,
+              status: $status,
+              transition: $transition,
+              manifest_set_id: $manifest_set_id,
+              base_sha: $base_sha,
+              updates_commit_sha: (if $updates_commit_sha == "" then null else $updates_commit_sha end),
+              deploy_required: $deploy_required,
+              endpoint_sha256: {
+                "browser/stable/WINNT/x86_64/update.xml": $win_hash,
+                "browser/stable/Linux/x86_64/update.xml": $linux_hash,
+                "browser/stable/Linux/aarch64/update.xml": $linux_aarch64_hash,
+                "browser/stable/Darwin/x86_64/update.xml": $mac_x64_hash,
+                "browser/stable/Darwin/aarch64/update.xml": $mac_aarch64_hash
+              }
+            }' > "$RESULT_FILE"
+
+          if [[ "$DRY_RUN" == "true" ]]; then
+            BUNDLE="$RUNNER_TEMP/stable-update-staging"
+            mkdir -p "$BUNDLE/browser/stable/WINNT/x86_64" \
+              "$BUNDLE/browser/stable/Linux/x86_64" \
+              "$BUNDLE/browser/stable/Linux/aarch64" \
+              "$BUNDLE/browser/stable/Darwin/x86_64" \
+              "$BUNDLE/browser/stable/Darwin/aarch64"
+            cp browser/stable/WINNT/x86_64/update.xml "$BUNDLE/browser/stable/WINNT/x86_64/update.xml"
+            cp browser/stable/Linux/x86_64/update.xml "$BUNDLE/browser/stable/Linux/x86_64/update.xml"
+            cp browser/stable/Linux/aarch64/update.xml "$BUNDLE/browser/stable/Linux/aarch64/update.xml"
+            cp browser/stable/Darwin/x86_64/update.xml "$BUNDLE/browser/stable/Darwin/x86_64/update.xml"
+            cp browser/stable/Darwin/aarch64/update.xml "$BUNDLE/browser/stable/Darwin/aarch64/update.xml"
+            cp browser/stable/stable-state.json "$BUNDLE/browser/stable/stable-state.json"
+            cp "$RUNNER_TEMP/stable-update.diff" "$BUNDLE/stable-update.diff"
+          fi
+
+          {
+            echo "### Stable update v2 result"
+            echo
+            echo "- Request: \`$REQUEST_ID\`"
+            echo "- Status: \`$STATUS\`"
+            echo "- Manifest set: \`$MANIFEST_SET_ID\`"
+            echo "- Updates commit: \`${UPDATES_COMMIT_SHA:-none (dry run)}\`"
+            echo "- Deploy required: \`$DEPLOY_REQUIRED\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload correlated result
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: stable-update-result-${{ inputs['request-id'] }}
+          path: |
+            ${{ runner.temp }}/stable-update-result.json
+            ${{ runner.temp }}/stable-update-staging
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/upload-cfp.yml
+++ b/.github/workflows/upload-cfp.yml
@@ -1,20 +1,58 @@
-on: [push]
+name: Deploy Floorp Updates to Cloudflare Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: floorp-updates-production-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     name: Deploy to Cloudflare Pages
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 1
+          ref: ${{ github.sha }}
+
+      - name: Verify exact deployment commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          CHECKED_OUT_SHA=$(git rev-parse HEAD)
+          if [[ "$CHECKED_OUT_SHA" != "$GITHUB_SHA" ]]; then
+            echo "Expected checkout $GITHUB_SHA, got $CHECKED_OUT_SHA" >&2
+            exit 1
+          fi
+
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22.x"
 
+      - name: Verify commit is still latest main
+        shell: bash
+        run: |
+          set -euo pipefail
+          LATEST_MAIN_SHA=$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')
+          if [[ "$LATEST_MAIN_SHA" != "$GITHUB_SHA" ]]; then
+            echo "Refusing stale production deploy: event SHA $GITHUB_SHA is no longer main ($LATEST_MAIN_SHA)" >&2
+            exit 1
+          fi
+
       - name: Publish
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: |
-            pages deploy . --project-name=floorp-updates --branch=main
+            pages deploy . --project-name=floorp-updates --branch=main --commit-hash=${{ github.sha }}

--- a/browser/stable/stable-state.json
+++ b/browser/stable/stable-state.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "status": "legacy-bootstrap",
+  "version": "153.0",
+  "app_version2": "12.16.3",
+  "baseline_commit": "56ab92f48524374d569b467d8f423658d9b8b610",
+  "targets": {
+    "browser/stable/WINNT/x86_64/update.xml": {
+      "buildid": "20260721164720",
+      "buildid2": "019f8b5e-6a66-701a-8e8e-452db858e53a",
+      "url": "https://github.com/Floorp-Projects/Floorp/releases/download/v12.16.3/floorp-windows-x86_64-full.mar",
+      "size": 108702809
+    },
+    "browser/stable/Linux/x86_64/update.xml": {
+      "buildid": "20260721163542",
+      "buildid2": "019f8b5e-a5cc-71ca-86ad-8c944ec24739",
+      "url": "https://github.com/Floorp-Projects/Floorp/releases/download/v12.16.3/floorp-linux-x86_64-full.mar",
+      "size": 98380317
+    },
+    "browser/stable/Linux/aarch64/update.xml": {
+      "buildid": "20260721132359",
+      "buildid2": "019f8b5e-293c-719e-810d-c56eb9382cd9",
+      "url": "https://github.com/Floorp-Projects/Floorp/releases/download/v12.16.3/floorp-linux-aarch64-full.mar",
+      "size": 85160448
+    },
+    "browser/stable/Darwin/x86_64/update.xml": {
+      "buildid": "20260721011812",
+      "buildid2": "019f8b5e-5810-76c1-a3ff-24576b8dbbcf",
+      "url": "https://github.com/Floorp-Projects/Floorp/releases/download/v12.16.3/floorp-mac-universal-full.mar",
+      "size": 150527849
+    },
+    "browser/stable/Darwin/aarch64/update.xml": {
+      "buildid": "20260721011812",
+      "buildid2": "019f8b5e-5810-76c1-a3ff-24576b8dbbcf",
+      "url": "https://github.com/Floorp-Projects/Floorp/releases/download/v12.16.3/floorp-mac-universal-full.mar",
+      "size": 150527849
+    }
+  }
+}

--- a/scripts/stable-update-v2.ts
+++ b/scripts/stable-update-v2.ts
@@ -1,0 +1,988 @@
+import { basename, dirname, join, resolve } from "node:path";
+
+const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const SHA512_PATTERN = /^[0-9a-f]{128}$/;
+const SHA1_PATTERN = /^[0-9a-f]{40}$/;
+const BUILD_ID_PATTERN = /^\d{14}$/;
+const UUID_V7_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const FIREFOX_VERSION_PATTERN =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))?$/;
+const DETAILS_URL = "https://blog.floorp.app/categories/release/";
+
+export const TARGET_DEFINITIONS = [
+  {
+    key: "windows",
+    platform: "WINNT",
+    metadataArch: "x86_64",
+    assetName: "floorp-windows-x86_64-full.mar",
+    metaName: "win-meta.json",
+    endpoints: [["WINNT", "x86_64"]] as const,
+  },
+  {
+    key: "linux",
+    platform: "Linux",
+    metadataArch: "x86_64",
+    assetName: "floorp-linux-x86_64-full.mar",
+    metaName: "linux-meta.json",
+    endpoints: [["Linux", "x86_64"]] as const,
+  },
+  {
+    key: "linuxAarch64",
+    platform: "Linux",
+    metadataArch: "aarch64",
+    assetName: "floorp-linux-aarch64-full.mar",
+    metaName: "linux-aarch64-meta.json",
+    endpoints: [["Linux", "aarch64"]] as const,
+  },
+  {
+    key: "mac",
+    platform: "Darwin",
+    metadataArch: "universal",
+    assetName: "floorp-mac-universal-full.mar",
+    metaName: "mac-meta.json",
+    endpoints: [["Darwin", "x86_64"], ["Darwin", "aarch64"]] as const,
+  },
+] as const;
+
+export type TargetKey = (typeof TARGET_DEFINITIONS)[number]["key"];
+
+export interface ArtifactInput {
+  metaPath: string;
+  marPath: string;
+  marUrl: string;
+}
+
+export interface StableUpdateInput {
+  firefoxVersion: string;
+  appVersion2: string;
+  artifacts: Record<TargetKey, ArtifactInput>;
+  statePath: string;
+  outputRoot: string;
+}
+
+interface MarMetadata {
+  url: string;
+  name: string;
+  size: number;
+  sha512: string;
+}
+
+interface ProvenanceMetadata {
+  runtime_repository: string;
+  runtime_head_sha: string;
+  runtime_run_id: number;
+  runtime_artifact_id: number;
+  runtime_artifact_digest: string;
+  floorp_repository: string;
+  floorp_head_sha: string;
+  floorp_run_id: number;
+  release_tag: string;
+}
+
+interface VerificationMetadata {
+  status: string;
+  method: string;
+  app_build_id: string;
+  build_id2: string;
+}
+
+export interface ValidatedMetadata {
+  schema_version: 2;
+  version_display: string;
+  version: string;
+  noraneko_version: string;
+  buildid: string;
+  noraneko_buildid: string;
+  channel: "release";
+  platform: "WINNT" | "Linux" | "Darwin";
+  arch: "x86_64" | "aarch64" | "universal";
+  manifest_set_id: string;
+  mar: MarMetadata;
+  provenance: ProvenanceMetadata;
+  verification: VerificationMetadata;
+  metadata_sha256: string;
+}
+
+export interface ValidatedManifestSet {
+  firefoxVersion: string;
+  appVersion2: string;
+  manifestSetId: string;
+  floorpHeadSha: string;
+  floorpRunId: number;
+  releaseTag: string;
+  metadata: Record<TargetKey, ValidatedMetadata>;
+}
+
+interface LegacyTargetState {
+  buildid: string;
+  buildid2: string;
+  url: string;
+  size: number;
+}
+
+export interface LegacyState {
+  schema_version: 1;
+  status: "legacy-bootstrap";
+  version: string;
+  app_version2: string;
+  baseline_commit: string;
+  targets: Record<string, LegacyTargetState>;
+}
+
+interface VerifiedTargetState extends LegacyTargetState {
+  platform: string;
+  arch: string;
+  metadata_arch: string;
+  name: string;
+  sha512: string;
+  metadata_sha256: string;
+}
+
+export interface VerifiedState {
+  schema_version: 1;
+  status: "verified";
+  manifest_set_id: string;
+  version: string;
+  app_version2: string;
+  floorp_head_sha: string;
+  floorp_run_id: number;
+  targets: Record<string, VerifiedTargetState>;
+}
+
+export type StableState = LegacyState | VerifiedState;
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}
+
+function fail(message: string): never {
+  throw new ValidationError(message);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function record(value: unknown, path: string): Record<string, unknown> {
+  if (!isRecord(value)) fail(`${path} must be an object`);
+  return value;
+}
+
+function stringField(
+  value: Record<string, unknown>,
+  key: string,
+  path: string,
+): string {
+  const result = value[key];
+  if (typeof result !== "string" || result.length === 0) {
+    fail(`${path}.${key} must be a non-empty string`);
+  }
+  return result;
+}
+
+function positiveIntegerField(
+  value: Record<string, unknown>,
+  key: string,
+  path: string,
+): number {
+  const result = value[key];
+  if (!Number.isSafeInteger(result) || (result as number) <= 0) {
+    fail(`${path}.${key} must be a positive safe integer`);
+  }
+  return result as number;
+}
+
+function expectEqual(actual: unknown, expected: unknown, path: string): void {
+  if (actual !== expected) {
+    fail(
+      `${path} must equal ${JSON.stringify(expected)}; got ${
+        JSON.stringify(actual)
+      }`,
+    );
+  }
+}
+
+function expectPattern(value: string, pattern: RegExp, path: string): void {
+  if (!pattern.test(value)) fail(`${path} has an invalid format`);
+}
+
+function validateBuildId(value: string, path: string): void {
+  expectPattern(value, BUILD_ID_PATTERN, path);
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(4, 6));
+  const day = Number(value.slice(6, 8));
+  const hour = Number(value.slice(8, 10));
+  const minute = Number(value.slice(10, 12));
+  const second = Number(value.slice(12, 14));
+  const date = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+  const roundTrip = [
+    date.getUTCFullYear().toString().padStart(4, "0"),
+    (date.getUTCMonth() + 1).toString().padStart(2, "0"),
+    date.getUTCDate().toString().padStart(2, "0"),
+    date.getUTCHours().toString().padStart(2, "0"),
+    date.getUTCMinutes().toString().padStart(2, "0"),
+    date.getUTCSeconds().toString().padStart(2, "0"),
+  ].join("");
+  if (roundTrip !== value) fail(`${path} is not a valid UTC timestamp`);
+}
+
+interface SemVer {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+}
+
+function parseSemVer(value: string, path: string): SemVer {
+  const match =
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
+      .exec(
+        value,
+      );
+  if (!match) fail(`${path} must be a valid semantic version`);
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4]?.split(".") ?? [],
+  };
+}
+
+export function compareSemVer(left: string, right: string): number {
+  const a = parseSemVer(left, "left version");
+  const b = parseSemVer(right, "right version");
+  for (const key of ["major", "minor", "patch"] as const) {
+    if (a[key] !== b[key]) return a[key] < b[key] ? -1 : 1;
+  }
+  if (a.prerelease.length === 0 || b.prerelease.length === 0) {
+    if (a.prerelease.length === b.prerelease.length) return 0;
+    return a.prerelease.length === 0 ? 1 : -1;
+  }
+  const length = Math.max(a.prerelease.length, b.prerelease.length);
+  for (let index = 0; index < length; index++) {
+    const av = a.prerelease[index];
+    const bv = b.prerelease[index];
+    if (av === undefined) return -1;
+    if (bv === undefined) return 1;
+    if (av === bv) continue;
+    const an = /^\d+$/.test(av);
+    const bn = /^\d+$/.test(bv);
+    if (an && bn) return Number(av) < Number(bv) ? -1 : 1;
+    if (an !== bn) return an ? -1 : 1;
+    return av < bv ? -1 : 1;
+  }
+  return 0;
+}
+
+export function compareFirefoxVersion(left: string, right: string): number {
+  expectPattern(left, FIREFOX_VERSION_PATTERN, "left Firefox version");
+  expectPattern(right, FIREFOX_VERSION_PATTERN, "right Firefox version");
+  const a = left.split(".").map((part) => BigInt(part));
+  const b = right.split(".").map((part) => BigInt(part));
+  for (let index = 0; index < 3; index++) {
+    const av = a[index] ?? 0n;
+    const bv = b[index] ?? 0n;
+    if (av !== bv) return av < bv ? -1 : 1;
+  }
+  return 0;
+}
+
+function bytesToHex(bytes: ArrayBuffer): string {
+  return Array.from(
+    new Uint8Array(bytes),
+    (byte) => byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+async function digestBytes(
+  algorithm: "SHA-256" | "SHA-512",
+  bytes: Uint8Array,
+): Promise<string> {
+  return bytesToHex(
+    await crypto.subtle.digest(algorithm, bytes as Uint8Array<ArrayBuffer>),
+  );
+}
+
+export function canonicalReleaseUrl(
+  appVersion2: string,
+  assetName: string,
+): string {
+  return `https://github.com/Floorp-Projects/Floorp/releases/download/v${appVersion2}/${assetName}`;
+}
+
+async function validateOneMetadata(
+  definition: (typeof TARGET_DEFINITIONS)[number],
+  input: ArtifactInput,
+  firefoxVersion: string,
+  appVersion2: string,
+): Promise<ValidatedMetadata> {
+  const path = definition.key;
+  const expectedUrl = canonicalReleaseUrl(appVersion2, definition.assetName);
+  expectEqual(input.marUrl, expectedUrl, `${path} dispatch MAR URL`);
+
+  let bytes: Uint8Array;
+  let parsed: unknown;
+  try {
+    bytes = await Deno.readFile(input.metaPath);
+    parsed = JSON.parse(new TextDecoder().decode(bytes));
+  } catch (error) {
+    fail(
+      `${path} metadata cannot be read as JSON: ${(error as Error).message}`,
+    );
+  }
+  const root = record(parsed, path);
+  expectEqual(root.schema_version, 2, `${path}.schema_version`);
+  const versionDisplay = stringField(root, "version_display", path);
+  expectEqual(
+    versionDisplay,
+    `${appVersion2}@${firefoxVersion}`,
+    `${path}.version_display`,
+  );
+  const version = stringField(root, "version", path);
+  expectEqual(version, firefoxVersion, `${path}.version`);
+  const noranekoVersion = stringField(root, "noraneko_version", path);
+  expectEqual(noranekoVersion, appVersion2, `${path}.noraneko_version`);
+  const buildid = stringField(root, "buildid", path);
+  validateBuildId(buildid, `${path}.buildid`);
+  const buildid2 = stringField(root, "noraneko_buildid", path);
+  expectPattern(buildid2, UUID_V7_PATTERN, `${path}.noraneko_buildid`);
+  expectEqual(root.channel, "release", `${path}.channel`);
+  expectEqual(root.platform, definition.platform, `${path}.platform`);
+  expectEqual(root.arch, definition.metadataArch, `${path}.arch`);
+  const manifestSetId = stringField(root, "manifest_set_id", path);
+  expectPattern(manifestSetId, SHA256_PATTERN, `${path}.manifest_set_id`);
+
+  const marRoot = record(root.mar, `${path}.mar`);
+  const marUrl = stringField(marRoot, "url", `${path}.mar`);
+  expectEqual(marUrl, input.marUrl, `${path}.mar.url`);
+  const marName = stringField(marRoot, "name", `${path}.mar`);
+  expectEqual(marName, definition.assetName, `${path}.mar.name`);
+  const marSize = positiveIntegerField(marRoot, "size", `${path}.mar`);
+  const marSha512 = stringField(marRoot, "sha512", `${path}.mar`);
+  expectPattern(marSha512, SHA512_PATTERN, `${path}.mar.sha512`);
+
+  let marBytes: Uint8Array;
+  let marStat: Deno.FileInfo;
+  try {
+    marStat = await Deno.stat(input.marPath);
+    if (!marStat.isFile) fail(`${path} MAR path is not a file`);
+    marBytes = await Deno.readFile(input.marPath);
+  } catch (error) {
+    if (error instanceof ValidationError) throw error;
+    fail(`${path} MAR cannot be read: ${(error as Error).message}`);
+  }
+  expectEqual(marStat.size, marSize, `${path}.mar.size versus downloaded MAR`);
+  const actualSha512 = await digestBytes("SHA-512", marBytes);
+  expectEqual(
+    actualSha512,
+    marSha512,
+    `${path}.mar.sha512 versus downloaded MAR`,
+  );
+
+  const provenanceRoot = record(root.provenance, `${path}.provenance`);
+  const runtimeRepository = stringField(
+    provenanceRoot,
+    "runtime_repository",
+    `${path}.provenance`,
+  );
+  expectEqual(
+    runtimeRepository,
+    "Floorp-Projects/Floorp-Runtime",
+    `${path}.provenance.runtime_repository`,
+  );
+  const runtimeHeadSha = stringField(
+    provenanceRoot,
+    "runtime_head_sha",
+    `${path}.provenance`,
+  );
+  expectPattern(
+    runtimeHeadSha,
+    SHA1_PATTERN,
+    `${path}.provenance.runtime_head_sha`,
+  );
+  const runtimeRunId = positiveIntegerField(
+    provenanceRoot,
+    "runtime_run_id",
+    `${path}.provenance`,
+  );
+  const runtimeArtifactId = positiveIntegerField(
+    provenanceRoot,
+    "runtime_artifact_id",
+    `${path}.provenance`,
+  );
+  const runtimeArtifactDigest = stringField(
+    provenanceRoot,
+    "runtime_artifact_digest",
+    `${path}.provenance`,
+  );
+  expectPattern(
+    runtimeArtifactDigest,
+    SHA256_PATTERN,
+    `${path}.provenance.runtime_artifact_digest`,
+  );
+  const floorpRepository = stringField(
+    provenanceRoot,
+    "floorp_repository",
+    `${path}.provenance`,
+  );
+  expectEqual(
+    floorpRepository,
+    "Floorp-Projects/Floorp",
+    `${path}.provenance.floorp_repository`,
+  );
+  const floorpHeadSha = stringField(
+    provenanceRoot,
+    "floorp_head_sha",
+    `${path}.provenance`,
+  );
+  expectPattern(
+    floorpHeadSha,
+    SHA1_PATTERN,
+    `${path}.provenance.floorp_head_sha`,
+  );
+  const floorpRunId = positiveIntegerField(
+    provenanceRoot,
+    "floorp_run_id",
+    `${path}.provenance`,
+  );
+  const releaseTag = stringField(
+    provenanceRoot,
+    "release_tag",
+    `${path}.provenance`,
+  );
+  expectEqual(releaseTag, `v${appVersion2}`, `${path}.provenance.release_tag`);
+
+  const verificationRoot = record(root.verification, `${path}.verification`);
+  expectEqual(
+    verificationRoot.status,
+    "verified",
+    `${path}.verification.status`,
+  );
+  expectEqual(
+    verificationRoot.method,
+    "full-version",
+    `${path}.verification.method`,
+  );
+  const appBuildId = stringField(
+    verificationRoot,
+    "app_build_id",
+    `${path}.verification`,
+  );
+  expectEqual(appBuildId, buildid, `${path}.verification.app_build_id`);
+  const verificationBuildId2 = stringField(
+    verificationRoot,
+    "build_id2",
+    `${path}.verification`,
+  );
+  expectEqual(
+    verificationBuildId2,
+    buildid2,
+    `${path}.verification.build_id2`,
+  );
+
+  return {
+    schema_version: 2,
+    version_display: versionDisplay,
+    version,
+    noraneko_version: noranekoVersion,
+    buildid,
+    noraneko_buildid: buildid2,
+    channel: "release",
+    platform: definition.platform,
+    arch: definition.metadataArch,
+    manifest_set_id: manifestSetId,
+    mar: { url: marUrl, name: marName, size: marSize, sha512: marSha512 },
+    provenance: {
+      runtime_repository: runtimeRepository,
+      runtime_head_sha: runtimeHeadSha,
+      runtime_run_id: runtimeRunId,
+      runtime_artifact_id: runtimeArtifactId,
+      runtime_artifact_digest: runtimeArtifactDigest,
+      floorp_repository: floorpRepository,
+      floorp_head_sha: floorpHeadSha,
+      floorp_run_id: floorpRunId,
+      release_tag: releaseTag,
+    },
+    verification: {
+      status: "verified",
+      method: "full-version",
+      app_build_id: appBuildId,
+      build_id2: verificationBuildId2,
+    },
+    metadata_sha256: `sha256:${await digestBytes("SHA-256", bytes!)}`,
+  };
+}
+
+export async function validateManifestSet(
+  input: Pick<
+    StableUpdateInput,
+    "firefoxVersion" | "appVersion2" | "artifacts"
+  >,
+): Promise<ValidatedManifestSet> {
+  expectPattern(
+    input.firefoxVersion,
+    FIREFOX_VERSION_PATTERN,
+    "firefox-version",
+  );
+  parseSemVer(input.appVersion2, "app-version2");
+
+  const metadata = {} as Record<TargetKey, ValidatedMetadata>;
+  for (const definition of TARGET_DEFINITIONS) {
+    metadata[definition.key] = await validateOneMetadata(
+      definition,
+      input.artifacts[definition.key],
+      input.firefoxVersion,
+      input.appVersion2,
+    );
+  }
+  const first = metadata.windows;
+  for (const definition of TARGET_DEFINITIONS.slice(1)) {
+    const value = metadata[definition.key];
+    for (
+      const key of ["version", "noraneko_version", "manifest_set_id"] as const
+    ) {
+      expectEqual(
+        value[key],
+        first[key],
+        `${definition.key}.${key} across manifest set`,
+      );
+    }
+    for (
+      const key of ["floorp_head_sha", "floorp_run_id", "release_tag"] as const
+    ) {
+      expectEqual(
+        value.provenance[key],
+        first.provenance[key],
+        `${definition.key}.provenance.${key} across manifest set`,
+      );
+    }
+    for (
+      const key of [
+        "runtime_repository",
+        "runtime_head_sha",
+        "runtime_run_id",
+      ] as const
+    ) {
+      expectEqual(
+        value.provenance[key],
+        first.provenance[key],
+        `${definition.key}.provenance.${key} across manifest set`,
+      );
+    }
+  }
+
+  const recomputedManifestSetId = await computeManifestSetId(metadata);
+  for (const definition of TARGET_DEFINITIONS) {
+    expectEqual(
+      metadata[definition.key].manifest_set_id,
+      recomputedManifestSetId,
+      `${definition.key}.manifest_set_id versus canonical manifest set`,
+    );
+  }
+
+  return {
+    firefoxVersion: input.firefoxVersion,
+    appVersion2: input.appVersion2,
+    manifestSetId: first.manifest_set_id,
+    floorpHeadSha: first.provenance.floorp_head_sha,
+    floorpRunId: first.provenance.floorp_run_id,
+    releaseTag: first.provenance.release_tag,
+    metadata,
+  };
+}
+
+export function buildManifestSetIdentity(
+  metadata: Record<TargetKey, ValidatedMetadata>,
+): Record<string, unknown> {
+  const first = metadata.windows;
+  return {
+    schema_version: 2,
+    floorp: {
+      repository: first.provenance.floorp_repository,
+      head_sha: first.provenance.floorp_head_sha,
+      run_id: first.provenance.floorp_run_id,
+      release_tag: first.provenance.release_tag,
+    },
+    targets: TARGET_DEFINITIONS.map((definition) => {
+      const value = metadata[definition.key];
+      return {
+        platform: value.platform,
+        arch: value.arch,
+        mar: {
+          name: value.mar.name,
+          size: value.mar.size,
+          sha512: value.mar.sha512,
+        },
+        runtime: {
+          repository: value.provenance.runtime_repository,
+          head_sha: value.provenance.runtime_head_sha,
+          run_id: value.provenance.runtime_run_id,
+          artifact_id: value.provenance.runtime_artifact_id,
+          artifact_digest: value.provenance.runtime_artifact_digest,
+        },
+        verification: {
+          app_build_id: value.verification.app_build_id,
+          build_id2: value.verification.build_id2,
+        },
+      };
+    }),
+  };
+}
+
+export async function computeManifestSetId(
+  metadata: Record<TargetKey, ValidatedMetadata>,
+): Promise<string> {
+  const identity = buildManifestSetIdentity(metadata);
+  return `sha256:${await digestBytes(
+    "SHA-256",
+    new TextEncoder().encode(canonicalJson(identity)),
+  )}`;
+}
+
+const ENDPOINT_KEYS = TARGET_DEFINITIONS.flatMap((definition) =>
+  definition.endpoints.map(([platform, arch]) =>
+    `browser/stable/${platform}/${arch}/update.xml`
+  )
+);
+
+function validateState(value: unknown): StableState {
+  const root = record(value, "stable state");
+  expectEqual(root.schema_version, 1, "stable state.schema_version");
+  const status = stringField(root, "status", "stable state");
+  const version = stringField(root, "version", "stable state");
+  expectPattern(version, FIREFOX_VERSION_PATTERN, "stable state.version");
+  const appVersion2 = stringField(root, "app_version2", "stable state");
+  parseSemVer(appVersion2, "stable state.app_version2");
+  const targets = record(root.targets, "stable state.targets");
+  const targetKeys = Object.keys(targets).sort();
+  expectEqual(
+    JSON.stringify(targetKeys),
+    JSON.stringify([...ENDPOINT_KEYS].sort()),
+    "stable state target keys",
+  );
+
+  if (status === "legacy-bootstrap") {
+    const baselineCommit = stringField(root, "baseline_commit", "stable state");
+    expectPattern(baselineCommit, SHA1_PATTERN, "stable state.baseline_commit");
+    for (const key of ENDPOINT_KEYS) {
+      const target = record(targets[key], `stable state.targets.${key}`);
+      validateBuildId(
+        stringField(target, "buildid", `stable state.targets.${key}`),
+        `stable state.targets.${key}.buildid`,
+      );
+      expectPattern(
+        stringField(target, "buildid2", `stable state.targets.${key}`),
+        UUID_V7_PATTERN,
+        `stable state.targets.${key}.buildid2`,
+      );
+      stringField(target, "url", `stable state.targets.${key}`);
+      positiveIntegerField(target, "size", `stable state.targets.${key}`);
+    }
+    return root as unknown as LegacyState;
+  }
+
+  if (status === "verified") {
+    expectPattern(
+      stringField(root, "manifest_set_id", "stable state"),
+      SHA256_PATTERN,
+      "stable state.manifest_set_id",
+    );
+    expectPattern(
+      stringField(root, "floorp_head_sha", "stable state"),
+      SHA1_PATTERN,
+      "stable state.floorp_head_sha",
+    );
+    positiveIntegerField(root, "floorp_run_id", "stable state");
+    for (const key of ENDPOINT_KEYS) {
+      const target = record(targets[key], `stable state.targets.${key}`);
+      validateBuildId(
+        stringField(target, "buildid", `stable state.targets.${key}`),
+        `stable state.targets.${key}.buildid`,
+      );
+      expectPattern(
+        stringField(target, "buildid2", `stable state.targets.${key}`),
+        UUID_V7_PATTERN,
+        `stable state.targets.${key}.buildid2`,
+      );
+      for (
+        const name of [
+          "platform",
+          "arch",
+          "metadata_arch",
+          "url",
+          "name",
+        ] as const
+      ) {
+        stringField(target, name, `stable state.targets.${key}`);
+      }
+      positiveIntegerField(target, "size", `stable state.targets.${key}`);
+      expectPattern(
+        stringField(target, "sha512", `stable state.targets.${key}`),
+        SHA512_PATTERN,
+        `stable state.targets.${key}.sha512`,
+      );
+      expectPattern(
+        stringField(target, "metadata_sha256", `stable state.targets.${key}`),
+        SHA256_PATTERN,
+        `stable state.targets.${key}.metadata_sha256`,
+      );
+    }
+    return root as unknown as VerifiedState;
+  }
+
+  fail(`stable state.status must be "legacy-bootstrap" or "verified"`);
+}
+
+export function buildVerifiedState(
+  manifest: ValidatedManifestSet,
+): VerifiedState {
+  const targets: Record<string, VerifiedTargetState> = {};
+  for (const definition of TARGET_DEFINITIONS) {
+    const metadata = manifest.metadata[definition.key];
+    for (const [platform, arch] of definition.endpoints) {
+      targets[`browser/stable/${platform}/${arch}/update.xml`] = {
+        platform,
+        arch,
+        metadata_arch: metadata.arch,
+        buildid: metadata.buildid,
+        buildid2: metadata.noraneko_buildid,
+        url: metadata.mar.url,
+        name: metadata.mar.name,
+        size: metadata.mar.size,
+        sha512: metadata.mar.sha512,
+        metadata_sha256: metadata.metadata_sha256,
+      };
+    }
+  }
+  return {
+    schema_version: 1,
+    status: "verified",
+    manifest_set_id: manifest.manifestSetId,
+    version: manifest.firefoxVersion,
+    app_version2: manifest.appVersion2,
+    floorp_head_sha: manifest.floorpHeadSha,
+    floorp_run_id: manifest.floorpRunId,
+    targets,
+  };
+}
+
+export function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (isRecord(value)) {
+    return `{${
+      Object.keys(value).sort().map((key) =>
+        `${JSON.stringify(key)}:${canonicalJson(value[key])}`
+      ).join(",")
+    }}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function determineTransition(
+  current: StableState,
+  next: VerifiedState,
+): "update" | "noop" {
+  if (compareFirefoxVersion(next.version, current.version) < 0) {
+    fail(
+      `new manifest must not downgrade Firefox version from ${current.version} to ${next.version}`,
+    );
+  }
+
+  if (current.status === "legacy-bootstrap") {
+    if (compareSemVer(next.app_version2, current.app_version2) <= 0) {
+      fail(
+        `legacy bootstrap only accepts a newer app version than ${current.app_version2}; got ${next.app_version2}`,
+      );
+    }
+    return "update";
+  }
+
+  if (current.manifest_set_id === next.manifest_set_id) {
+    if (canonicalJson(current) !== canonicalJson(next)) {
+      fail("manifest_set_id was reused with different verified state content");
+    }
+    return "noop";
+  }
+
+  if (compareSemVer(next.app_version2, current.app_version2) <= 0) {
+    fail(
+      `new manifest must have a newer app version than ${current.app_version2}; got ${next.app_version2}`,
+    );
+  }
+  return "update";
+}
+
+function renderUpdateXml(
+  metadata: ValidatedMetadata,
+  manifest: ValidatedManifestSet,
+): string {
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    "<updates>",
+    `    <update type="minor" displayVersion="${manifest.firefoxVersion}@${manifest.appVersion2}" appVersion="${manifest.firefoxVersion}" platformVersion="${manifest.firefoxVersion}" buildID="${metadata.buildid}" appVersion2="${manifest.appVersion2}" buildID2="${metadata.noraneko_buildid}" detailsURL="${DETAILS_URL}">`,
+    `        <patch type="complete" URL="${metadata.mar.url}" hashFunction="sha512" hashValue="${metadata.mar.sha512}" size="${metadata.mar.size}"/>`,
+    "    </update>",
+    "</updates>",
+    "",
+  ].join("\n");
+}
+
+interface PendingReplacement {
+  temporary: string;
+  destination: string;
+}
+
+async function publishAtomically(
+  outputRoot: string,
+  statePath: string,
+  manifest: ValidatedManifestSet,
+  state: VerifiedState,
+): Promise<void> {
+  const root = resolve(outputRoot);
+  const stateDestination = resolve(statePath);
+  if (stateDestination !== join(root, "stable-state.json")) {
+    fail("state-file must be stable-state.json directly under output-root");
+  }
+  await Deno.mkdir(dirname(root), { recursive: true });
+  const stageRoot = await Deno.makeTempDir({
+    dir: dirname(root),
+    prefix: ".stable-update-v2-stage-",
+  });
+  const replacements: PendingReplacement[] = [];
+  try {
+    for (const definition of TARGET_DEFINITIONS) {
+      const xml = renderUpdateXml(manifest.metadata[definition.key], manifest);
+      for (const [platform, arch] of definition.endpoints) {
+        const staged = join(stageRoot, platform, arch, "update.xml");
+        await Deno.mkdir(dirname(staged), { recursive: true });
+        await Deno.writeTextFile(staged, xml);
+      }
+    }
+    const stagedState = join(stageRoot, "stable-state.json");
+    await Deno.writeTextFile(
+      stagedState,
+      `${JSON.stringify(state, null, 2)}\n`,
+    );
+
+    const stagedFiles = TARGET_DEFINITIONS.flatMap((definition) =>
+      definition.endpoints.map(([platform, arch]) => ({
+        staged: join(stageRoot, platform, arch, "update.xml"),
+        destination: join(root, platform, arch, "update.xml"),
+      }))
+    );
+    stagedFiles.push({ staged: stagedState, destination: stateDestination });
+
+    for (const file of stagedFiles) {
+      await Deno.mkdir(dirname(file.destination), { recursive: true });
+      const temporary = join(
+        dirname(file.destination),
+        `.${basename(file.destination)}.${crypto.randomUUID()}.tmp`,
+      );
+      await Deno.copyFile(file.staged, temporary);
+      replacements.push({ temporary, destination: file.destination });
+    }
+    for (const replacement of replacements) {
+      await Deno.rename(replacement.temporary, replacement.destination);
+    }
+  } finally {
+    for (const replacement of replacements) {
+      try {
+        await Deno.remove(replacement.temporary);
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          console.warn(
+            `Could not remove temporary replacement ${replacement.temporary}: ${error}`,
+          );
+        }
+      }
+    }
+    await Deno.remove(stageRoot, { recursive: true });
+  }
+}
+
+export async function applyStableUpdate(
+  input: StableUpdateInput,
+): Promise<"updated" | "noop"> {
+  const manifest = await validateManifestSet(input);
+  let stateJson: unknown;
+  try {
+    stateJson = JSON.parse(await Deno.readTextFile(input.statePath));
+  } catch (error) {
+    fail(`stable state cannot be read as JSON: ${(error as Error).message}`);
+  }
+  const current = validateState(stateJson);
+  const next = buildVerifiedState(manifest);
+  const transition = determineTransition(current, next);
+  if (transition === "noop") return "noop";
+  await publishAtomically(input.outputRoot, input.statePath, manifest, next);
+  return "updated";
+}
+
+function parseFlags(args: string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!flag?.startsWith("--") || value === undefined) {
+      fail(
+        `arguments must be --name value pairs; got ${flag ?? "end of input"}`,
+      );
+    }
+    const name = flag.slice(2);
+    if (name in result) fail(`duplicate argument --${name}`);
+    result[name] = value;
+  }
+  return result;
+}
+
+function requireFlag(flags: Record<string, string>, name: string): string {
+  const value = flags[name];
+  if (!value) fail(`missing required argument --${name}`);
+  return value;
+}
+
+async function main(args: string[]): Promise<void> {
+  const flags = parseFlags(args);
+  const allowed = new Set([
+    "firefox-version",
+    "app-version2",
+    "state-file",
+    "output-root",
+    ...TARGET_DEFINITIONS.flatMap((definition) => [
+      `${definition.key}-meta`,
+      `${definition.key}-mar`,
+      `${definition.key}-mar-url`,
+    ]),
+  ]);
+  for (const name of Object.keys(flags)) {
+    if (!allowed.has(name)) fail(`unknown argument --${name}`);
+  }
+  const artifacts = Object.fromEntries(
+    TARGET_DEFINITIONS.map((definition) => [definition.key, {
+      metaPath: requireFlag(flags, `${definition.key}-meta`),
+      marPath: requireFlag(flags, `${definition.key}-mar`),
+      marUrl: requireFlag(flags, `${definition.key}-mar-url`),
+    }]),
+  ) as Record<TargetKey, ArtifactInput>;
+  const result = await applyStableUpdate({
+    firefoxVersion: requireFlag(flags, "firefox-version"),
+    appVersion2: requireFlag(flags, "app-version2"),
+    statePath: requireFlag(flags, "state-file"),
+    outputRoot: requireFlag(flags, "output-root"),
+    artifacts,
+  });
+  console.log(JSON.stringify({ result }));
+}
+
+if (import.meta.main) {
+  try {
+    await main(Deno.args);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    Deno.exit(1);
+  }
+}

--- a/scripts/stable-update-v2_test.ts
+++ b/scripts/stable-update-v2_test.ts
@@ -1,0 +1,610 @@
+import {
+  applyStableUpdate,
+  buildVerifiedState,
+  canonicalReleaseUrl,
+  compareFirefoxVersion,
+  compareSemVer,
+  computeManifestSetId,
+  determineTransition,
+  type LegacyState,
+  type StableUpdateInput,
+  TARGET_DEFINITIONS,
+  type TargetKey,
+  type ValidatedMetadata,
+  validateManifestSet,
+  type VerifiedState,
+} from "./stable-update-v2.ts";
+
+function assert(
+  condition: unknown,
+  message = "assertion failed",
+): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function assertEquals(
+  actual: unknown,
+  expected: unknown,
+  message?: string,
+): void {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      message ??
+        `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+async function assertRejects(
+  action: () => Promise<unknown> | unknown,
+  expectedMessage: string,
+): Promise<void> {
+  try {
+    await action();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    assert(
+      message.includes(expectedMessage),
+      `expected error containing ${JSON.stringify(expectedMessage)}, got ${
+        JSON.stringify(message)
+      }`,
+    );
+    return;
+  }
+  throw new Error(
+    `expected rejection containing ${JSON.stringify(expectedMessage)}`,
+  );
+}
+
+function nested(
+  value: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  const result = value[key];
+  assert(
+    typeof result === "object" && result !== null && !Array.isArray(result),
+    `${key} must be an object in test fixture`,
+  );
+  return result as Record<string, unknown>;
+}
+
+async function hexDigest(
+  algorithm: "SHA-256" | "SHA-512",
+  bytes: Uint8Array,
+): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    algorithm,
+    bytes as Uint8Array<ArrayBuffer>,
+  );
+  return Array.from(
+    new Uint8Array(digest),
+    (byte) => byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+interface Fixture {
+  root: string;
+  input: StableUpdateInput;
+  metas: Record<TargetKey, Record<string, unknown>>;
+}
+
+const BUILD_IDS: Record<TargetKey, string> = {
+  windows: "20260722010101",
+  linux: "20260722010202",
+  linuxAarch64: "20260722010303",
+  mac: "20260722010404",
+};
+
+const BUILD_IDS_2: Record<TargetKey, string> = {
+  windows: "019f9000-0000-7000-8000-000000000001",
+  linux: "019f9000-0000-7000-8000-000000000002",
+  linuxAarch64: "019f9000-0000-7000-8000-000000000003",
+  mac: "019f9000-0000-7000-8000-000000000004",
+};
+
+async function refreshManifestSetId(fixture: Fixture): Promise<string> {
+  const forIdentity = Object.fromEntries(
+    TARGET_DEFINITIONS.map((definition) => [definition.key, {
+      ...fixture.metas[definition.key],
+      metadata_sha256: `sha256:${"0".repeat(64)}`,
+    }]),
+  ) as unknown as Record<TargetKey, ValidatedMetadata>;
+  const manifestSetId = await computeManifestSetId(forIdentity);
+  for (const definition of TARGET_DEFINITIONS) {
+    fixture.metas[definition.key].manifest_set_id = manifestSetId;
+  }
+  return manifestSetId;
+}
+
+async function writeMetas(fixture: Fixture): Promise<void> {
+  for (const definition of TARGET_DEFINITIONS) {
+    await Deno.writeTextFile(
+      fixture.input.artifacts[definition.key].metaPath,
+      `${JSON.stringify(fixture.metas[definition.key], null, 2)}\n`,
+    );
+  }
+}
+
+async function createFixture(appVersion2 = "12.16.4"): Promise<Fixture> {
+  const root = await Deno.makeTempDir({ prefix: "stable-update-v2-test-" });
+  const outputRoot = `${root}/browser/stable`;
+  await Deno.mkdir(outputRoot, { recursive: true });
+  const statePath = `${outputRoot}/stable-state.json`;
+  const bootstrapUrl = new URL(
+    "../browser/stable/stable-state.json",
+    import.meta.url,
+  );
+  await Deno.copyFile(bootstrapUrl, statePath);
+
+  const artifacts = {} as Record<
+    TargetKey,
+    StableUpdateInput["artifacts"][TargetKey]
+  >;
+  const metas = {} as Record<TargetKey, Record<string, unknown>>;
+  for (let index = 0; index < TARGET_DEFINITIONS.length; index++) {
+    const definition = TARGET_DEFINITIONS[index];
+    const marBytes = new TextEncoder().encode(`test MAR ${definition.key}`);
+    const marPath = `${root}/${definition.assetName}`;
+    const metaPath = `${root}/${definition.metaName}`;
+    const marUrl = canonicalReleaseUrl(appVersion2, definition.assetName);
+    await Deno.writeFile(marPath, marBytes);
+    artifacts[definition.key] = { marPath, metaPath, marUrl };
+    metas[definition.key] = {
+      schema_version: 2,
+      version_display: `${appVersion2}@153.0`,
+      version: "153.0",
+      noraneko_version: appVersion2,
+      buildid: BUILD_IDS[definition.key],
+      noraneko_buildid: BUILD_IDS_2[definition.key],
+      channel: "release",
+      platform: definition.platform,
+      arch: definition.metadataArch,
+      manifest_set_id: "pending",
+      mar: {
+        url: marUrl,
+        name: definition.assetName,
+        size: marBytes.byteLength,
+        sha512: await hexDigest("SHA-512", marBytes),
+      },
+      provenance: {
+        runtime_repository: "Floorp-Projects/Floorp-Runtime",
+        runtime_head_sha: "b".repeat(40),
+        runtime_run_id: 1000,
+        runtime_artifact_id: 2000 + index,
+        runtime_artifact_digest: `sha256:${
+          (index + 5).toString(16).repeat(64)
+        }`,
+        floorp_repository: "Floorp-Projects/Floorp",
+        floorp_head_sha: "a".repeat(40),
+        floorp_run_id: 3000,
+        release_tag: `v${appVersion2}`,
+      },
+      verification: {
+        status: "verified",
+        method: "full-version",
+        app_build_id: BUILD_IDS[definition.key],
+        build_id2: BUILD_IDS_2[definition.key],
+      },
+    };
+  }
+
+  const fixture: Fixture = {
+    root,
+    input: {
+      firefoxVersion: "153.0",
+      appVersion2,
+      artifacts,
+      statePath,
+      outputRoot,
+    },
+    metas,
+  };
+  await refreshManifestSetId(fixture);
+  await writeMetas(fixture);
+  return fixture;
+}
+
+async function usingFixture(
+  action: (fixture: Fixture) => Promise<void>,
+  appVersion2 = "12.16.4",
+): Promise<void> {
+  const fixture = await createFixture(appVersion2);
+  try {
+    await action(fixture);
+  } finally {
+    await Deno.remove(fixture.root, { recursive: true });
+  }
+}
+
+Deno.test("semantic version comparison follows SemVer precedence", () => {
+  assert(compareSemVer("12.16.4", "12.16.3") > 0);
+  assert(compareSemVer("12.17.0", "12.16.99") > 0);
+  assert(compareSemVer("12.17.0-rc.2", "12.17.0-rc.1") > 0);
+  assert(compareSemVer("12.17.0", "12.17.0-rc.2") > 0);
+  assertEquals(compareSemVer("12.17.0+build.2", "12.17.0+build.1"), 0);
+});
+
+Deno.test("Firefox dotted-version comparison prevents engine rollback", () => {
+  assert(compareFirefoxVersion("154.0", "153.0.9") > 0);
+  assert(compareFirefoxVersion("153.0.1", "153.0") > 0);
+  assertEquals(compareFirefoxVersion("153.0", "153.0.0"), 0);
+  assert(compareFirefoxVersion("152.9.9", "153.0") < 0);
+});
+
+Deno.test("valid schema-v2 manifest set validates all four downloaded MARs", async () => {
+  await usingFixture(async (fixture) => {
+    const manifest = await validateManifestSet(fixture.input);
+    assertEquals(manifest.appVersion2, "12.16.4");
+    assertEquals(
+      manifest.manifestSetId,
+      fixture.metas.windows.manifest_set_id,
+    );
+  });
+});
+
+const invalidCases: Array<{
+  name: string;
+  expected: string;
+  mutate: (fixture: Fixture) => unknown | Promise<unknown>;
+}> = [
+  {
+    name: "schema version",
+    expected: "windows.schema_version",
+    mutate: (fixture) => fixture.metas.windows.schema_version = 1,
+  },
+  {
+    name: "Firefox version",
+    expected: "windows.version",
+    mutate: (fixture) => fixture.metas.windows.version = "152.0",
+  },
+  {
+    name: "metadata display version order",
+    expected: "windows.version_display",
+    mutate: (fixture) =>
+      fixture.metas.windows.version_display = "153.0@12.16.4",
+  },
+  {
+    name: "invalid UTC buildid",
+    expected: "not a valid UTC timestamp",
+    mutate: (fixture) => fixture.metas.windows.buildid = "20260230010101",
+  },
+  {
+    name: "non-UUIDv7 buildid2",
+    expected: "windows.noraneko_buildid has an invalid format",
+    mutate: (fixture) =>
+      fixture.metas.windows.noraneko_buildid =
+        "019f9000-0000-6000-8000-000000000001",
+  },
+  {
+    name: "channel",
+    expected: "windows.channel",
+    mutate: (fixture) => fixture.metas.windows.channel = "beta",
+  },
+  {
+    name: "platform",
+    expected: "windows.platform",
+    mutate: (fixture) => fixture.metas.windows.platform = "Linux",
+  },
+  {
+    name: "architecture",
+    expected: "windows.arch",
+    mutate: (fixture) => fixture.metas.windows.arch = "aarch64",
+  },
+  {
+    name: "MAR URL",
+    expected: "windows.mar.url",
+    mutate: (fixture) =>
+      nested(fixture.metas.windows, "mar").url =
+        "https://example.invalid/file.mar",
+  },
+  {
+    name: "MAR asset name",
+    expected: "windows.mar.name",
+    mutate: (fixture) =>
+      nested(fixture.metas.windows, "mar").name = "wrong.mar",
+  },
+  {
+    name: "MAR size",
+    expected: "windows.mar.size versus downloaded MAR",
+    mutate: (fixture) => nested(fixture.metas.windows, "mar").size = 999,
+  },
+  {
+    name: "MAR SHA512",
+    expected: "windows.mar.sha512 versus downloaded MAR",
+    mutate: (fixture) =>
+      nested(fixture.metas.windows, "mar").sha512 = "f".repeat(128),
+  },
+  {
+    name: "Runtime repository provenance",
+    expected: "windows.provenance.runtime_repository",
+    mutate: (fixture) =>
+      nested(fixture.metas.windows, "provenance").runtime_repository =
+        "wrong/repo",
+  },
+  {
+    name: "Floorp head SHA provenance",
+    expected: "windows.provenance.floorp_head_sha has an invalid format",
+    mutate: (fixture) =>
+      nested(fixture.metas.windows, "provenance").floorp_head_sha = "not-a-sha",
+  },
+  {
+    name: "verification status",
+    expected: "windows.verification.status",
+    mutate: (fixture) =>
+      nested(fixture.metas.windows, "verification").status = "unverified",
+  },
+  {
+    name: "verified application build ID",
+    expected: "windows.verification.app_build_id",
+    mutate: (fixture) =>
+      nested(fixture.metas.windows, "verification").app_build_id =
+        "20260722000000",
+  },
+];
+
+for (const invalidCase of invalidCases) {
+  Deno.test(`fail closed on invalid ${invalidCase.name}`, async () => {
+    await usingFixture(async (fixture) => {
+      await invalidCase.mutate(fixture);
+      await writeMetas(fixture);
+      await assertRejects(
+        () => validateManifestSet(fixture.input),
+        invalidCase.expected,
+      );
+    });
+  });
+}
+
+Deno.test("rejects a manifest ID not derived from canonical provenance and target identities", async () => {
+  await usingFixture(async (fixture) => {
+    for (const definition of TARGET_DEFINITIONS) {
+      fixture.metas[definition.key].manifest_set_id = `sha256:${
+        "f".repeat(64)
+      }`;
+    }
+    await writeMetas(fixture);
+    await assertRejects(
+      () => validateManifestSet(fixture.input),
+      "manifest_set_id versus canonical manifest set",
+    );
+  });
+});
+
+Deno.test("rejects manifest-set disagreement across platform metadata", async () => {
+  await usingFixture(async (fixture) => {
+    fixture.metas.linux.manifest_set_id = `sha256:${"e".repeat(64)}`;
+    await writeMetas(fixture);
+    await assertRejects(
+      () => validateManifestSet(fixture.input),
+      "linux.manifest_set_id across manifest set",
+    );
+  });
+});
+
+Deno.test("rejects a manifest set mixed from different Runtime runs", async () => {
+  await usingFixture(async (fixture) => {
+    nested(fixture.metas.linux, "provenance").runtime_run_id = 9999;
+    await writeMetas(fixture);
+    await assertRejects(
+      () => validateManifestSet(fixture.input),
+      "linux.provenance.runtime_run_id across manifest set",
+    );
+  });
+});
+
+Deno.test("generates all five XMLs with verified SHA512 before publishing state", async () => {
+  await usingFixture(async (fixture) => {
+    assertEquals(await applyStableUpdate(fixture.input), "updated");
+    const paths = [
+      "WINNT/x86_64/update.xml",
+      "Linux/x86_64/update.xml",
+      "Linux/aarch64/update.xml",
+      "Darwin/x86_64/update.xml",
+      "Darwin/aarch64/update.xml",
+    ];
+    for (const path of paths) {
+      const xml = await Deno.readTextFile(
+        `${fixture.input.outputRoot}/${path}`,
+      );
+      assert(xml.includes('displayVersion="153.0@12.16.4"'));
+      assert(xml.includes('hashFunction="sha512"'));
+      assert(xml.includes('hashValue="'));
+    }
+    assertEquals(
+      await Deno.readTextFile(
+        `${fixture.input.outputRoot}/Darwin/x86_64/update.xml`,
+      ),
+      await Deno.readTextFile(
+        `${fixture.input.outputRoot}/Darwin/aarch64/update.xml`,
+      ),
+    );
+    const state = JSON.parse(await Deno.readTextFile(fixture.input.statePath));
+    assertEquals(state.status, "verified");
+    assertEquals(state.manifest_set_id, fixture.metas.windows.manifest_set_id);
+    assertEquals(Object.keys(state.targets).length, 5);
+  });
+});
+
+Deno.test("validation failure leaves every existing endpoint untouched", async () => {
+  await usingFixture(async (fixture) => {
+    const paths = TARGET_DEFINITIONS.flatMap((definition) =>
+      definition.endpoints.map(([platform, arch]) =>
+        `${platform}/${arch}/update.xml`
+      )
+    );
+    for (const path of paths) {
+      await Deno.mkdir(
+        `${fixture.input.outputRoot}/${
+          path.substring(0, path.lastIndexOf("/"))
+        }`,
+        {
+          recursive: true,
+        },
+      );
+      await Deno.writeTextFile(
+        `${fixture.input.outputRoot}/${path}`,
+        `sentinel:${path}`,
+      );
+    }
+    nested(fixture.metas.linux, "mar").sha512 = "0".repeat(128);
+    await writeMetas(fixture);
+    await assertRejects(
+      () => applyStableUpdate(fixture.input),
+      "linux.mar.sha512 versus downloaded MAR",
+    );
+    for (const path of paths) {
+      assertEquals(
+        await Deno.readTextFile(`${fixture.input.outputRoot}/${path}`),
+        `sentinel:${path}`,
+      );
+    }
+  });
+});
+
+Deno.test("state transition rejects rollback and equivocation, but same manifest is a no-op", async () => {
+  await usingFixture(async (fixture) => {
+    const manifest = await validateManifestSet(fixture.input);
+    const next = buildVerifiedState(manifest);
+    const legacy = JSON.parse(
+      await Deno.readTextFile(fixture.input.statePath),
+    ) as LegacyState;
+    assertEquals(determineTransition(legacy, next), "update");
+
+    const sameLegacyVersion = structuredClone(next);
+    sameLegacyVersion.app_version2 = legacy.app_version2;
+    await assertRejects(
+      () => determineTransition(legacy, sameLegacyVersion),
+      "legacy bootstrap only accepts a newer app version",
+    );
+
+    const engineDowngrade = structuredClone(next);
+    engineDowngrade.app_version2 = "12.17.0";
+    engineDowngrade.version = "152.0";
+    engineDowngrade.manifest_set_id = `sha256:${"d".repeat(64)}`;
+    await assertRejects(
+      () => determineTransition(next, engineDowngrade),
+      "must not downgrade Firefox version from 153.0 to 152.0",
+    );
+
+    assertEquals(determineTransition(next, structuredClone(next)), "noop");
+
+    const reusedId = structuredClone(next);
+    reusedId.targets[Object.keys(reusedId.targets)[0]].size++;
+    await assertRejects(
+      () => determineTransition(next, reusedId),
+      "manifest_set_id was reused",
+    );
+
+    const sameVersionDifferentManifest = structuredClone(next);
+    sameVersionDifferentManifest.manifest_set_id = `sha256:${"f".repeat(64)}`;
+    await assertRejects(
+      () => determineTransition(next, sameVersionDifferentManifest),
+      "new manifest must have a newer app version",
+    );
+
+    const older = structuredClone(sameVersionDifferentManifest);
+    older.app_version2 = "12.16.3";
+    await assertRejects(
+      () => determineTransition(next, older),
+      "new manifest must have a newer app version",
+    );
+
+    const newer = structuredClone(
+      sameVersionDifferentManifest,
+    ) as VerifiedState;
+    newer.app_version2 = "12.17.0";
+    assertEquals(determineTransition(next, newer), "update");
+  });
+});
+
+Deno.test("applying the exact same verified manifest performs no writes", async () => {
+  await usingFixture(async (fixture) => {
+    assertEquals(await applyStableUpdate(fixture.input), "updated");
+    const before = await Deno.readTextFile(fixture.input.statePath);
+    assertEquals(await applyStableUpdate(fixture.input), "noop");
+    assertEquals(await Deno.readTextFile(fixture.input.statePath), before);
+  });
+});
+
+Deno.test("legacy delivery workflow cannot target stable, rc, or beta", async () => {
+  const workflow = await Deno.readTextFile(
+    new URL(
+      "../.github/workflows/deliver-updates-to-floorp-browser.yml",
+      import.meta.url,
+    ),
+  );
+  assert(
+    workflow.includes(
+      'if [[ ! "$dir" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+$ ]]; then',
+    ),
+    "legacy directory loop must allowlist numeric version directories",
+  );
+  assert(
+    workflow.includes(
+      "^browser/[0-9]+\\.[0-9]+\\.[0-9]+/(WINNT|Linux|Darwin)/(x86_64|x86|aarch64)/update\\.xml$",
+    ),
+    "legacy staging must enforce the per-version endpoint allowlist",
+  );
+  assert(
+    !workflow.includes('if [[ "$dir" != "beta" ]]'),
+    "a beta-only denylist would leave stable and rc writable",
+  );
+  assert(
+    !workflow.includes("git add ."),
+    "legacy workflow must not stage the repository broadly",
+  );
+  assert(
+    !workflow.includes("git pull -r"),
+    "legacy workflow must reject drift instead of rebasing generated output",
+  );
+});
+
+Deno.test("v2 workflow serializes writers and rejects stale broad git updates", async () => {
+  const workflow = await Deno.readTextFile(
+    new URL(
+      "../.github/workflows/update-stable-updatexml-files-v2.yml",
+      import.meta.url,
+    ),
+  );
+  for (
+    const input of [
+      "win-mar-url",
+      "linux-mar-url",
+      "linux-aarch64-mar-url",
+      "mac-mar-url",
+      "win-meta-url",
+      "linux-meta-url",
+      "linux-aarch64-meta-url",
+      "mac-meta-url",
+      "firefox-version",
+      "app-version2",
+      "request-id",
+      "dry-run",
+    ]
+  ) {
+    assert(workflow.includes(`      ${input}:`), `missing v2 input ${input}`);
+  }
+  assert(workflow.includes("group: floorp-updates-writer"));
+  assert(workflow.includes("cancel-in-progress: false"));
+  assert(workflow.includes("REMOTE_SHA=$(git rev-parse origin/main)"));
+  assert(workflow.includes('if [[ "$REMOTE_SHA" != "$BASE_SHA" ]]'));
+  assert(workflow.includes("git add -- \\"));
+  assert(!workflow.includes("git add ."));
+  assert(!workflow.includes("git pull -r"));
+  assert(workflow.includes("git push origin HEAD:main"));
+  assert(workflow.includes("stable-update-result-${{ inputs['request-id'] }}"));
+});
+
+Deno.test("Cloudflare production deploy is main-only and pinned to the pushed SHA", async () => {
+  const workflow = await Deno.readTextFile(
+    new URL("../.github/workflows/upload-cfp.yml", import.meta.url),
+  );
+  assert(workflow.includes("      - main"));
+  assert(workflow.includes("github.ref == 'refs/heads/main'"));
+  assert(workflow.includes("ref: ${{ github.sha }}"));
+  assert(workflow.includes('if [[ "$CHECKED_OUT_SHA" != "$GITHUB_SHA" ]]'));
+  assert(workflow.includes("git ls-remote --exit-code origin refs/heads/main"));
+  assert(workflow.includes('if [[ "$LATEST_MAIN_SHA" != "$GITHUB_SHA" ]]'));
+  assert(workflow.includes("--commit-hash=${{ github.sha }}"));
+  assert(!workflow.includes("on: [push]"));
+});


### PR DESCRIPTION
## Summary

- adds a fail-closed schema-v2 stable update validator and five-endpoint generator
- binds all platform metadata and MARs to one canonical manifest set with provenance, SHA-512, size, and state-transition checks
- prevents stale writers and legacy workflows from overwriting stable/rc data
- restricts Cloudflare production deployment to the latest exact `main` commit

## Root cause and emergency state

Floorp-Projects/Floorp#2584 was not caused by the Windows request URL. The initially published 12.16.3 XML used BuildID `20260721191913`, while the shipped Windows binary reported `20260721164720`; the updater therefore kept offering the same version.

The emergency correction is already on `main` as commit `56ab92f`. A live probe of `https://updates.floorp.app/browser/stable/WINNT/x86_64/update.xml?force=1` returned HTTP 200 with `displayVersion=153.0@12.16.3` and `buildID=20260721164720`.

## Rollout

This PR intentionally leaves the existing stable workflow available during cutover. Merge this PR before Floorp-Projects/Floorp#2589 so the v2 updater workflow exists on `main` when the release publisher switches callers. The current `56ab92f` hotfix is the bootstrap state.

## Validation

- `deno check scripts/stable-update-v2.ts scripts/stable-update-v2_test.ts`
- `deno fmt --check ...`
- `deno lint scripts/stable-update-v2.ts scripts/stable-update-v2_test.ts`
- `deno test --allow-read --allow-write scripts/stable-update-v2_test.ts` (29 passed)
- Actionlint v1.7.12
- `git diff --check`
- all 452 existing update XML files parsed successfully
- PR Cloudflare Pages check passed

No v2 production updater workflow was dispatched and no production deployment was performed from this branch. The first production call remains gated on the ordered multi-repository rollout.

Closes the delivery-side portion of Floorp-Projects/Floorp#2584.